### PR TITLE
fix(security): scope TruffleHog hook to staged files only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,10 +63,11 @@ repos:
       - id: trufflehog
         name: TruffleHog Secret Scanner
         description: Detect secrets in your data before committing
-        entry: >-
-          bash -c 'command -v trufflehog >/dev/null 2>&1 &&
-          trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail ||
-          echo "TruffleHog not installed - skipping"'
+        # Scan staged files only. The git-history mode (--since-commit HEAD) also
+        # traverses fetched remote branches in the local object store, producing
+        # false positives from unmerged branches. Staged-file scanning is the
+        # correct scope for a pre-commit hook; git history scanning belongs in CI.
+        entry: bash -c 'command -v trufflehog >/dev/null 2>&1 && (git diff --cached -z --diff-filter=d --name-only 2>/dev/null | xargs -0 -r trufflehog filesystem --fail --no-update --results=verified,unknown) || echo "TruffleHog not installed - skipping secret scan"'
         language: system
         pass_filenames: false
         stages: [pre-commit]


### PR DESCRIPTION
## Summary

Replace `trufflehog git file://. --since-commit HEAD` with a staged-files form.

## Why

Resolves observation #4 from the skill observation log; part of the fleet-wide
TruffleHog rollout. See `.claude/rules/pre-commit.md` `PC-HOOK-STAGED-SCOPE`.

Generated with [Claude Code](https://claude.ai/code)