### PR TITLE
docs: complete Google-style docstring coverage (99.2% → 100%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Filled in remaining missing docstrings to reach 100% interrogate coverage
+  (up from 99.2%): module docstring for `python_libs.middleware`, docstring +
+  type annotations for the `mask_match` inner callback in
+  `cloudflare_auth.utils.mask_sensitive_data`, and docstring for the
+  `dependency` closure returned by `cloudflare_auth.middleware_enhanced.require_tier`.
+
 ### Changed
 
 - Migrated `sonarcloud.yml` to use `python-sonarcloud.yml` reusable workflow

--- a/packages/cloudflare-auth/src/cloudflare_auth/middleware_enhanced.py
+++ b/packages/cloudflare-auth/src/cloudflare_auth/middleware_enhanced.py
@@ -721,6 +721,23 @@ def require_tier(minimum_tier: UserTier) -> Callable:
     """
 
     def dependency(request: Request) -> CloudflareUser:
+        """Validate that the current user meets ``minimum_tier``.
+
+        Resolved as a FastAPI dependency by :func:`require_tier`. The user is
+        loaded from request state via :func:`get_current_user`; tiers are
+        ordered ``LIMITED < FULL < ADMIN``.
+
+        Args:
+            request: Incoming FastAPI/Starlette request.
+
+        Returns:
+            The authenticated :class:`CloudflareUser`.
+
+        Raises:
+            HTTPException: ``403`` if the user's tier is below
+                ``minimum_tier``; ``401`` (via :func:`get_current_user`) if
+                the request is unauthenticated.
+        """
         user = get_current_user(request)
 
         tier_order = {

--- a/packages/cloudflare-auth/src/cloudflare_auth/middleware_enhanced.py
+++ b/packages/cloudflare-auth/src/cloudflare_auth/middleware_enhanced.py
@@ -721,22 +721,21 @@ def require_tier(minimum_tier: UserTier) -> Callable:
     """
 
     def dependency(request: Request) -> CloudflareUser:
-        """Validate that the current user meets ``minimum_tier``.
+        """Validate that the current user meets minimum_tier.
 
-        Resolved as a FastAPI dependency by :func:`require_tier`. The user is
-        loaded from request state via :func:`get_current_user`; tiers are
-        ordered ``LIMITED < FULL < ADMIN``.
+        Resolved as a FastAPI dependency by require_tier. The user is loaded
+        from request state via get_current_user; tiers are ordered
+        LIMITED < FULL < ADMIN.
 
         Args:
             request: Incoming FastAPI/Starlette request.
 
         Returns:
-            The authenticated :class:`CloudflareUser`.
+            The authenticated CloudflareUser object.
 
         Raises:
-            HTTPException: ``403`` if the user's tier is below
-                ``minimum_tier``; ``401`` (via :func:`get_current_user`) if
-                the request is unauthenticated.
+            HTTPException: 403 if the user's tier is below minimum_tier; 401
+                (via get_current_user) if the request is unauthenticated.
         """
         user = get_current_user(request)
 

--- a/packages/cloudflare-auth/src/cloudflare_auth/utils.py
+++ b/packages/cloudflare-auth/src/cloudflare_auth/utils.py
@@ -224,12 +224,12 @@ def mask_sensitive_data(
     def mask_match(match: re.Match[str]) -> str:
         """Replace a regex match with a masked representation.
 
-        For email-like matches (containing ``@``), masks the local and domain
+        For email-like matches (containing '@'), masks the local and domain
         parts separately. For all other matches, replaces every character
-        with ``*``.
+        with '*'.
 
         Args:
-            match: Regex match object produced by :func:`re.sub`.
+            match: Regex match object produced by re.sub.
 
         Returns:
             Masked replacement string for the matched text.

--- a/packages/cloudflare-auth/src/cloudflare_auth/utils.py
+++ b/packages/cloudflare-auth/src/cloudflare_auth/utils.py
@@ -221,7 +221,19 @@ def mask_sensitive_data(
         'Contact ***@***.*** for help'
     """
 
-    def mask_match(match):
+    def mask_match(match: re.Match[str]) -> str:
+        """Replace a regex match with a masked representation.
+
+        For email-like matches (containing ``@``), masks the local and domain
+        parts separately. For all other matches, replaces every character
+        with ``*``.
+
+        Args:
+            match: Regex match object produced by :func:`re.sub`.
+
+        Returns:
+            Masked replacement string for the matched text.
+        """
         matched = match.group(0)
         if "@" in matched:
             # Email-like pattern

--- a/src/python_libs/middleware/__init__.py
+++ b/src/python_libs/middleware/__init__.py
@@ -1,0 +1,6 @@
+"""Middleware components for Python Libs.
+
+This namespace package is reserved for middleware modules (request/response
+hooks, ASGI/WSGI middleware, instrumentation). It is currently empty; submodules
+will be added here as middleware features are introduced.
+"""

--- a/src/python_libs/middleware/__init__.py
+++ b/src/python_libs/middleware/__init__.py
@@ -1,6 +1,6 @@
 """Middleware components for Python Libs.
 
-This namespace package is reserved for middleware modules (request/response
-hooks, ASGI/WSGI middleware, instrumentation). It is currently empty; submodules
-will be added here as middleware features are introduced.
+This package is reserved for middleware modules (request/response hooks,
+ASGI/WSGI middleware, instrumentation). It is currently empty; submodules will
+be added here as middleware features are introduced.
 """


### PR DESCRIPTION
## Summary

Audited the library against the four-step docstring brief (module / class / function & method / type hints) and filled in the only three items still missing a docstring. Every other public module, class, and function already has a Google-style docstring (`Args:` / `Returns:` / `Raises:`), so the diff is small and surgical — no business logic changes.

## Interrogate coverage (before / after)

Measured with `uvx interrogate -v src/ packages/*/src/` (interrogate 1.7.0).

| | Total | Missing | Coverage |
|---|---|---|---|
| **Before** | 374 | 3 | **99.2 %** |
| **After**  | 374 | 0 | **100.0 %** |

### Items that were missing

The three nodes interrogate flagged as `MISSED`, all of which are now documented:

1. `src/python_libs/middleware/__init__.py` — empty file, no module docstring. Added a module docstring describing the namespace package.
2. `cloudflare_auth.utils.mask_sensitive_data.mask_match` (utils.py:224) — inner regex-substitution callback. Added a Google-style docstring **and** parameter / return type annotations (`re.Match[str] -> str`, using only the already-imported stdlib `re` module — no new dependencies).
3. `cloudflare_auth.middleware_enhanced.require_tier.dependency` (middleware_enhanced.py:723) — closure returned as a FastAPI dependency. Added a docstring describing the `LIMITED < FULL < ADMIN` tier ordering and the `HTTPException` 403 raised when the user's tier is below the required minimum.

## Why so few changes?

The library was already heavily documented prior to this PR:

- All JWT files (`cloudflare_auth.validators`, `models`, `middleware`, `middleware_enhanced`) already document expected token format, validated claims, exceptions raised, and security assumptions (e.g. RS256 + Cloudflare-issued JWKS, audience/issuer validation, expiration checking).
- All GCS files (`gcs_utilities.client`, `exceptions`) already document the bucket / key contract, the env-var configuration (`GCP_SA_KEY`, `GCS_BUCKET`, `GCP_PROJECT`), and the `NotFound` → `GCSNotFoundError` mapping.
- The existing FastAPI `Request` parameters in `csrf.validate_request` and `utils.get_client_ip` are intentionally left un-annotated with `# noqa: ANN001` because `fastapi` / `starlette` are optional extras (`[project.optional-dependencies].fastapi`) — adding a hard import would violate the brief's "Do not introduce new dependencies" rule. These were left as-is.

## Verification

- `uvx interrogate src/ packages/*/src/` → `PASSED (minimum: 80.0%, actual: 100.0%)`
- `uv run ruff check` on the changed files → `All checks passed!`
- `pytest tests/` in `packages/cloudflare-auth` → **111 passed**
- Smoke-tested `mask_sensitive_data`, `sanitize_email`, `sanitize_for_logging` end-to-end — output identical to pre-change behavior.

## Test plan

- [x] Interrogate reports 100 % coverage
- [x] Ruff clean on changed files
- [x] cloudflare-auth test suite passes (111/111)
- [x] No public API surface changes (docstrings + one inner-function type annotation only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkwUHpBQ792foyRAQnHtGi)_