### PR TITLE
chore(renovate): switch to pep621 manager (uv-managed projects)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated `sonarcloud.yml` to use `python-sonarcloud.yml` reusable workflow
 - Migrated `pr-validation.yml` to use `python-supplemental-checks.yml` reusable workflow
 - Removed dependency on deprecated `python-pr-validation.yml` workflow
+- Switched Renovate `enabledManagers` from `poetry` to `pep621` so Renovate can detect dependencies in the uv-managed `pyproject.toml`
 
 ### Fixed
 

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "pep621"
       ],
       "matchDepTypes": [
-        "dependencies"
+        "project.dependencies"
       ],
       "groupName": "Python dependencies",
       "automerge": false,
@@ -43,7 +43,8 @@
         "pep621"
       ],
       "matchDepTypes": [
-        "devDependencies"
+        "dependency-groups",
+        "tool.uv.dev-dependencies"
       ],
       "groupName": "Python dev dependencies",
       "automerge": false,

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group Python dependencies by type",
       "matchManagers": [
-        "uv"
+        "pep621"
       ],
       "matchDepTypes": [
         "dependencies"
@@ -40,7 +40,7 @@
     {
       "description": "Group Python dev dependencies",
       "matchManagers": [
-        "uv"
+        "pep621"
       ],
       "matchDepTypes": [
         "devDependencies"
@@ -197,7 +197,7 @@
     }
   ],
   "enabledManagers": [
-    "uv",
+    "pep621",
     "github-actions"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group Python dependencies by type",
       "matchManagers": [
-        "poetry"
+        "uv"
       ],
       "matchDepTypes": [
         "dependencies"
@@ -40,7 +40,7 @@
     {
       "description": "Group Python dev dependencies",
       "matchManagers": [
-        "poetry"
+        "uv"
       ],
       "matchDepTypes": [
         "devDependencies"
@@ -151,12 +151,6 @@
   "python": {
     "enabled": true
   },
-  "poetry": {
-    "enabled": true,
-    "fileMatch": [
-      "(^|/)pyproject\\.toml$"
-    ]
-  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -191,9 +185,6 @@
   },
   "osvVulnerabilityAlerts": true,
   "transitiveRemediation": true,
-  "postUpdateOptions": [
-    "poetryMassage"
-  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -206,7 +197,7 @@
     }
   ],
   "enabledManagers": [
-    "poetry",
+    "uv",
     "github-actions"
   ]
 }


### PR DESCRIPTION
## Summary

This repo manages dependencies with uv (`uv.lock` present), but `renovate.json` declared:

```json
"enabledManagers": ["poetry", "github-actions"]
```

Renovate's `enabledManagers` is replace-not-merge, so the global config does not fill in `uv`. The `poetry` manager tries to parse `pyproject.toml`'s `[tool.poetry.dependencies]` table, but uv projects declare deps under `[project.dependencies]`. Result: Renovate silently parses zero Python deps and produces no PRs.

## Changes

- `enabledManagers`: `poetry` -> `uv`
- `packageRules[*].matchManagers`: `poetry` -> `uv`
- Removed top-level `"poetry": { ... }` block
- Removed `"poetryMassage"` from `postUpdateOptions`

## Test plan

- [ ] Renovate dashboard issue regenerates with Python dependency PRs after merge
- [ ] No regression in GitHub Actions dependency PRs