### PR TITLE
chore(deps): add detection-only dependabot.yml (Renovate sole PR-opener)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+# Detection-only: Renovate is the sole PR-opener. open-pull-requests-limit: 0
+# suppresses Dependabot version PRs. Dependabot alerts (a repo setting) remain
+# the multi-ecosystem detection ledger. Refs: standards CI-021 (amended), CI-074.
+updates:
+  - package-ecosystem: "pip"            # Python: pyproject.toml / requirements / uv
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "github-actions" # if .github/workflows/ present
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Adds a detection-only `.github/dependabot.yml` with `open-pull-requests-limit: 0` for each ecosystem, keeping Renovate as the sole PR-opener while Dependabot alerts (a repo setting) remain the multi-ecosystem detection ledger.

Ecosystems included (manifests verified present in clone):
- `pip` (pyproject.toml + uv.lock)
- `github-actions` (.github/workflows/ present)

Refs: standards CI-021 (amended), CI-074. Stage 4 Cat A.