### PR TITLE
fix(ci): make REUSE compliance check always run on PRs

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,12 +6,12 @@
 name: REUSE Compliance
 
 on:
+  # No paths filter: "Check REUSE Compliance" is a REQUIRED status check, so it
+  # must report on every PR. A paths filter would skip the workflow on changes
+  # that do not match (e.g. root-only files like renovate.json, since "**/*"
+  # does not match repository-root paths), leaving the required context pending
+  # forever and silently blocking the PR.
   pull_request:
-    paths:
-      - "**/*"
-      - "REUSE.toml"
-      - "LICENSES/**"
-      - ".github/workflows/reuse.yml"
   push:
     branches:
       - main


### PR DESCRIPTION
Required check `Check REUSE Compliance` was gated behind a paths filter whose `**/*` does not match repo-root files (e.g. `renovate.json`), so root-only PRs (#46, #42) skipped the workflow and blocked silently. Removing the paths filter makes the required gate always report. Same class of issue as the #48 keystone.