### PR TITLE
fix(ci): opt out of --no-build in org reusable workflow callers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,8 @@ jobs:
       id-token: write
     uses: ByronWilliamsCPA/.github/.github/workflows/python-docs.yml@987d517d3c8e4b180f4dd15de6d9575f0df91182 # main
     with:
+      # Repo uses hatchling; --no-build cannot install the editable root package
+      no-build: false
       python-version: '3.12'
       docs-directory: 'docs'
       source-directory: 'src'

--- a/.github/workflows/fips-compatibility.yml
+++ b/.github/workflows/fips-compatibility.yml
@@ -56,6 +56,8 @@ jobs:
       pull-requests: write
     uses: ByronWilliamsCPA/.github/.github/workflows/python-fips-compatibility.yml@987d517d3c8e4b180f4dd15de6d9575f0df91182 # main
     with:
+      # Repo uses hatchling; --no-build cannot install the editable root package
+      no-build: false
       strict-mode: ${{ github.event.inputs.strict_mode == 'true' }}
       include-tests: true
       fix-hints: true

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -41,6 +41,8 @@ jobs:
     name: Mutation Testing
     uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@987d517d3c8e4b180f4dd15de6d9575f0df91182 # main
     with:
+      # Repo uses hatchling; --no-build cannot install the editable root package
+      no-build: false
       python-version: '3.12'
       source-directory: 'src'
       test-directory: 'tests'

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -36,6 +36,8 @@ jobs:
   compatibility:
     uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@987d517d3c8e4b180f4dd15de6d9575f0df91182 # main
     with:
+      # Repo uses hatchling; --no-build cannot install the editable root package
+      no-build: false
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       operating-systems: '["ubuntu-latest"]'
       include-windows: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,7 +36,9 @@ jobs:
     with:
       # Repo uses hatchling; --no-build cannot install the editable root package
       no-build: false
-      sonar-organization: williaby
+      # Project ByronWilliamsCPA_python-libs lives in the byronwilliamscpa org
+      # (org williaby has no such project; the scanner 404s on analysis create)
+      sonar-organization: byronwilliamscpa
       sonar-project-key: ByronWilliamsCPA_python-libs
       python-version: '3.12'
       source-directory: 'src'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -34,6 +34,8 @@ jobs:
   sonarcloud:
     uses: ByronWilliamsCPA/.github/.github/workflows/python-sonarcloud.yml@987d517d3c8e4b180f4dd15de6d9575f0df91182 # main
     with:
+      # Repo uses hatchling; --no-build cannot install the editable root package
+      no-build: false
       sonar-organization: williaby
       sonar-project-key: ByronWilliamsCPA_python-libs
       python-version: '3.12'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the default broke editable installation of the hatchling root package
   ("marked as `--no-build` but has no binary distribution") on the docs,
   SonarCloud, and FIPS runs on `main`. Same fix as `sbom.yml` in #44.
+- Replaced the unsupported `packages/*/tests/` wildcard in `sonar.tests`
+  with the enumerated package test directories; SonarCloud rejects
+  wildcards in `sonar.sources`/`sonar.tests` and failed the scan.
 - Restored the required status-check contexts the org rulesets enforce, which had
   drifted out of sync during the monorepo conversion and were silently blocking
   every open PR (the missing contexts sat permanently pending):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Passed `no-build: false` to the org reusable workflows that gained a
+  default-on `--no-build` uv policy (`python-docs`, `python-sonarcloud`,
+  `python-fips-compatibility`, `python-mutation`, `python-compatibility`);
+  the default broke editable installation of the hatchling root package
+  ("marked as `--no-build` but has no binary distribution") on the docs,
+  SonarCloud, and FIPS runs on `main`. Same fix as `sbom.yml` in #44.
 - Restored the required status-check contexts the org rulesets enforce, which had
   drifted out of sync during the monorepo conversion and were silently blocking
   every open PR (the missing contexts sat permanently pending):

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,8 +15,13 @@ sonar.projectVersion=0.1.0
 # Source directories (comma-separated)
 sonar.sources=src/,packages/
 
-# Test directories (comma-separated)
-sonar.tests=tests/,packages/*/tests/
+# Test directories (comma-separated; SonarCloud does not support wildcards here)
+sonar.tests=\
+  tests/,\
+  packages/cloudflare-api/tests/,\
+  packages/cloudflare-auth/tests/,\
+  packages/gcs-utilities/tests/,\
+  packages/gemini-image/tests/
 
 # Python version
 sonar.python.version=3.12


### PR DESCRIPTION
## Summary

The org reusable workflows gained a `no-build` input defaulting to `true`, which passes `--no-build` to `uv sync`. That fails on this repo's editable hatchling root package:

```
error: Distribution `python-libs==0.1.0 @ editable+.` can't be installed because it is marked as `--no-build` but has no binary distribution
```

This is currently breaking the **docs**, **SonarCloud**, and **FIPS** runs on `main`, and would break the **compatibility** and **mutation** runs on their next scheduled trigger.

## Changes

Set `no-build: false` (the reusable workflows' own documented opt-out for hatchling projects) in all five callers:

- `.github/workflows/docs.yml`
- `.github/workflows/sonarcloud.yml`
- `.github/workflows/fips-compatibility.yml`
- `.github/workflows/mutation-testing.yml`
- `.github/workflows/python-compatibility.yml`

Same fix as applied to `sbom.yml` within #44 (commit a8e184b).

## Verification

- `sbom.yml` with the identical fix went green on #44 before merge.
- Post-merge, the docs / SonarCloud / FIPS workflows on `main` should pass on their next run.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Enhanced CI/CD workflows across documentation generation, FIPS compatibility verification, mutation testing, and code analysis by updating build and package installation configurations in multiple automated testing pipelines.
- Updated code quality scanning integration by replacing wildcard-based test directory patterns with explicit path configurations for improved reliability and accuracy.
- Updated code quality service organization identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->