### PR TITLE
chore(mcp): add context7 and sonarqube MCP servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@2.2.4"
+      ]
+    },
+    "sonarqube": {
+      "type": "http",
+      "url": "http://localhost:8090/mcp",
+      "headers": {
+        "Authorization": "Bearer ${SONARQUBE_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds project-scoped context7 and sonarqube (org port 8090) MCP servers so this code repo has them available in Claude Code. SonarQube endpoint is localhost-bound to the workstation, matching the existing pattern in ByronWilliamsCPA/.claude.