### PR TITLE
fix(ci): wire required checks for the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@
 name: CI
 
 on:
+  merge_group:
   push:
     branches: [main, master, develop]
   pull_request:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,7 @@
 name: PR Validation
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,6 +6,7 @@
 name: REUSE Compliance
 
 on:
+  merge_group:
   # No paths filter: "Check REUSE Compliance" is a REQUIRED status check, so it
   # must report on every PR. A paths filter would skip the workflow on changes
   # that do not match (e.g. root-only files like renovate.json, since "**/*"

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -10,6 +10,7 @@
 name: Security Analysis
 
 "on":
+  merge_group:
   push:
     branches: [main, master]
   pull_request:


### PR DESCRIPTION
## Summary

Adds a `merge_group` trigger to the four required-check workflows so each required context reports inside the merge queue.

## Files changed

- `.github/workflows/ci.yml`
- `.github/workflows/pr-validation.yml`
- `.github/workflows/reuse.yml`
- `.github/workflows/security-analysis.yml`

## Why

GitHub merge queues dispatch a `merge_group` event, not `pull_request`. A
required status check whose workflow does not trigger on `merge_group` never
reports on the queued commit, so the entry waits the full timeout and fails.
Required checks produced by reusable workflows surface as `caller-job /
callee-job`, which cannot match a bare ruleset context; the org pattern is an
in-line aggregator job named exactly the bare context.

## Landing this PR (deadlock)

For `merge_group` events GitHub uses the workflow definition from the default
branch, so this fix does not take effect in the queue until it is on `main`.
This repo's merge-queue ruleset has no bypass actor, so an admin must break the
deadlock once: temporarily set the `merge-queue` ruleset to **Evaluate** (or
Disabled), squash-merge this PR, then re-enable. Subsequent PRs drain normally.

## Validation

`actionlint` and `yamllint` (repo config) pass on the changed files; no new
findings introduced. Generated as part of an org-wide read-only audit.
