### PR TITLE
fix(sonarcloud): declare all supported Python versions to Sonar

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,8 +32,12 @@ permissions:
 
 jobs:
   sonarcloud:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-sonarcloud.yml@987d517d3c8e4b180f4dd15de6d9575f0df91182 # main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-sonarcloud.yml@4bd2d7c207a7fcf2dfcec8416c805d06d745c241 # main
     with:
+      # Every version requires-python (">=3.10,<3.15") admits, not just the build version.
+      # SonarPython gates version-specific rules on ALL declared versions, so declaring only
+      # 3.12 raises 3.11+ and 3.12+ rules against code that must still run on 3.10.
+      sonar-python-version: '3.10,3.11,3.12,3.13,3.14'
       # Repo uses hatchling; --no-build cannot install the editable root package
       no-build: false
       # Project ByronWilliamsCPA_python-libs lives in the byronwilliamscpa org

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,8 +23,10 @@ sonar.tests=\
   packages/gcs-utilities/tests/,\
   packages/gemini-image/tests/
 
-# Python version
-sonar.python.version=3.12
+# Versions the SOURCE supports, matching requires-python (">=3.10,<3.15"). CI overrides this
+# via -Dsonar.python.version from the sonar-python-version input, so this key only affects
+# local and IDE (SonarLint) analysis. Keep the two in sync.
+sonar.python.version=3.10,3.11,3.12,3.13,3.14
 
 # =============================================================================
 # Test Coverage Configuration


### PR DESCRIPTION
## Problem

`sonar.python.version` was `3.12`, the single version CI builds with, while this project's
`requires-python` is `">=3.10,<3.15"`.

SonarPython gates version-specific rules on **all** declared versions:
`PythonVersionUtils.areSourcePythonVersionsGreaterOrEqualThan` is an `allMatch`. Declaring
only `3.12` therefore satisfies every `>= 3.11` and `>= 3.12` gate, so those rules fire
against code that must still run on **3.10**.

## Preventive, not curative

SonarCloud reports **0** open `S6794`/`S6796` issues here today. The misconfiguration is real
but latent: it fires the first time this codebase grows a construct one of those rules covers,
such as a PEP 695 `type X = ...` alias, and then reports a finding the project cannot act on
without dropping 3.10 support. Flagging this so a green result is not read as evidence the
change was unnecessary.

## Fix

```yaml
sonar-python-version: '3.10,3.11,3.12,3.13,3.14'
```

3.14 joined the org supported set in ByronWilliamsCPA/.github#292, and `requires-python`'s
`<3.15` ceiling admits it.

`python-version` stays `3.12`. It feeds `actions/setup-python` and is the version the project
builds and tests with, a separate concern from the versions the source must remain compatible
with. Conflating the two is what caused this.

## Why the pin moves too

`sonar-python-version` is new in ByronWilliamsCPA/.github#291 and does not exist in the
previously pinned revision. Passing an input the callee does not declare fails a reusable
workflow at startup, so the pin moves to `4bd2d7c`, the squash commit of #291 on `main`.

## Also in this change

`sonar-project.properties` is synced to the same list. CI overrides it via `-D`, but SonarLint
in the IDE reads it, so leaving it at `3.12` would keep local analysis raising what CI does
not.

## Verification

- `actionlint` rc=0
- `pre-commit` scoped to the two changed files: every matching hook passes
- Only the two SonarCloud files are staged; nothing else in the tree is touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis to evaluate compatibility across Python 3.10–3.14.
  * Aligned analysis settings with the project’s supported Python versions.
  * Improved CI configuration documentation for Python version overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->